### PR TITLE
Major and minor fixes

### DIFF
--- a/content/docs/regulations/api-docs/regulations.json
+++ b/content/docs/regulations/api-docs/regulations.json
@@ -1,7 +1,7 @@
 {
   "apiVersion": "2.0.0",
     "swaggerVersion": "1.2",
-    "basePath": "http://api.data.gov/regulations/v2",
+    "basePath": "http://api.data.gov/regulations/beta",
   "apis": [
     {
       "operations": [
@@ -77,15 +77,14 @@
               "description": "FDMS Document ID",
               "name": "documentId",
               "paramType": "query",
-              "required": true,
+              "required": false,
               "type": "string"
             },
             {
-              "defaultValue": "2013-23804",
               "description": "Federal Register Document Number",
               "name": "federalRegisterNumber",
               "paramType": "query",
-              "required": true,
+              "required": false,
               "type": "string"
             }
           ],
@@ -115,6 +114,7 @@
               "type": "string"
             },
             {
+              "defaultValue": "DEMO_KEY",
               "description": "API Key",
               "name": "api_key",
               "paramType": "query",


### PR DESCRIPTION
- change url from v2 to beta
- remove required on both documentID and federalRegister number
- add DEMO_KEY as default value for api_key
