### PR TITLE
Adding api_key as a required field

### DIFF
--- a/content/docs/sam-testing/api-docs/registrations.json
+++ b/content/docs/sam-testing/api-docs/registrations.json
@@ -20,6 +20,13 @@
               "description": "DUNS+4 number (no '-' sign) of the registration to be fetched",
               "dataType": "string",
               "required": "true"
+            },
+            {
+              "paramType": "query",
+              "name": "api_key",
+              "description": "An API Key from api.data.gov",
+              "dataType": "string",
+              "required": "true"
             }
           ],
           "summary": "Find a registration by its DUN+4 number",


### PR DESCRIPTION
Forgot to include api_key as a required field for the API.
