### PR TITLE
Correct documentation - rate limit errors return 429s (not 503s)

### DIFF
--- a/source/docs/errors.md
+++ b/source/docs/errors.md
@@ -23,9 +23,9 @@ Certain, general errors will be returned in a standardized way from all Data.gov
       </td>
     </tr>
     <tr>
-      <th class="doc-parameter-name" scope="row">503</th>
+      <th class="doc-parameter-name" scope="row">429</th>
       <td class="doc-parameter-description">
-        Service Unavailable - Your API key has exceeded the rate limits. See <a href="/docs/rate-limits">rate limits</a> for more detail.
+        Too Many Requests - Your API key has exceeded the rate limits. See <a href="/docs/rate-limits">rate limits</a> for more detail.
       </td>
     </tr>
   </tbody>

--- a/source/docs/rate-limits.md
+++ b/source/docs/rate-limits.md
@@ -22,17 +22,7 @@ The hourly counters for your API key reset on a rolling basis.
 
 ## Rate Limit Error Response
 
-If your API key exceeds the rate limits, you will receive a response with an HTTP status code of 503, Service Unavailable. The response body will contain an error message reading "503 Service Unavailable (Rate Limit Exceeded)." For example, a JSON request that has exceed the rate limits would respond with:
-
-```json
-{
-  "errors":[
-    "503 Service Unavailable (Rate Limit Exceeded)"
-  ]
-}
-```
-
-For more details on how errors are returned, see the [general Web service errors](/docs/errors).
+If your API key exceeds the rate limits, you will receive a response with an HTTP status code of 429 (Too Many Requests).
 
 ## Need Higher Limits?
 


### PR DESCRIPTION
api.data.gov has always returned 429 response codes for rate limit errors. The references to 503s are just a vestige of old documentation.
