### PR TITLE
Two column home page layout

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,3 +1,5 @@
+require "active_support/core_ext/array/grouping"
+
 ###
 # Page options, layouts, aliases and proxies
 ###

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -8,17 +8,27 @@ disable_in_breadcrumbs_trail: true
 <hr>
 
 <div class="row">
-  <div class="col-md-6 feature feature-doc">
+  <div class="col-md-12 feature feature-doc">
     <h2><a href="/docs">Web Service Documentation</a></h2>
     <p>Explore our available Web services.</p>
-    <ul>
-      <% sitemap.find_resource_by_destination_path("/docs/index.html").children.sort_by { |p| p.data.title.to_s }.each do |child| %>
-        <% next if(child.data.hidden_child || child.data.title.to_s.blank?) %>
-        <li><%= link_to(child.data.title, child) %></li>
-      <% end %>
-    </ul>
+    <% children = sitemap.find_resource_by_destination_path("/docs/index.html").children.reject { |p| p.data.hidden_child || p.data.title.to_s.blank? }.sort_by { |p| p.data.title.to_s }.in_groups(2, false) %>
+    <div class="row">
+      <div class="col-md-6">
+        <ul>
+          <% children[0].each do |child| %>
+            <li><%= link_to(child.data.title, child) %></li>
+          <% end %>
+        </ul>
+      </div>
+      <div class="col-md-6">
+        <ul>
+          <% children[1].each do |child| %>
+            <li><%= link_to(child.data.title, child) %></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
   </div>
-
 </div>
 
 <hr>


### PR DESCRIPTION
Includes the changes in https://github.com/18F/api.data.gov/pull/469, and also tweaks the documentation links to be in 2 columns.