### PR TITLE
Add govinfo API contact

### DIFF
--- a/source/contact.html.md.erb
+++ b/source/contact.html.md.erb
@@ -21,6 +21,7 @@ api.data.gov provides a service for many different agency APIs. If you need supp
 - [Contact for General Services Administration - Data.gov CKAN API](https://www.data.gov/contact)
 - [Contact for General Services Administration - SAM](https://github.com/GSA/sam_api/issues)
 - [Contact for General Services Administration - Sustainable Facilities Tool](mailto:sftool@gsa.gov)
+- [Contact for Government Publishing Office - govinfo API](https://www.github.com/usgpo/api/issues)
 - [Contact for National Aeronautics and Space Administration - NASA Open APIs](mailto:nasa-api@lists.arc.nasa.gov)
 - [Contact for National Institutes of Health - 3D Print Exchange](mailto:3dprint@nih.gov)
 - [Contact for National Renewable Energy Laboratory - NREL Developer Network](https://developer.nrel.gov/contact/)


### PR DESCRIPTION
Just wanting to add a pointer to our issue tracker on github to help users get in touch with the govinfo API team. 