### PR TITLE
Update FEC email contact

### DIFF
--- a/source/contact.html.md.erb
+++ b/source/contact.html.md.erb
@@ -15,7 +15,7 @@ api.data.gov provides a service for many different agency APIs. If you need supp
 - [Contact for Department of Education - My Brother's Keeper APIs](mailto:developers@ed.gov)
 - [Contact for Federal Communications Commission - Accessibility Clearinghouse](mailto:DRO@fcc.gov)
 - [Contact for Federal Communications Commission - Electronic Comment Filing System (ECFS)](mailto:ECFSHelp@fcc.gov)
-- [Contact for Federal Election Commission - OpenFEC](mailto:18f-fec@gsa.gov)
+- [Contact for Federal Election Commission - OpenFEC](mailto:APIinfo@fec.gov)
 - [Contact for Food and Drug Administration - openFDA](mailto:open@fda.hhs.gov)
 - [Contact for General Services Administration - Auctions](https://github.com/GSA/Auctions_api/issues)
 - [Contact for General Services Administration - Data.gov CKAN API](https://www.data.gov/contact)


### PR DESCRIPTION
The [FEC API docs](https://api.open.fec.gov/developers/) show this email. We stopped using the 18F one years ago.
cc @lbeaufort